### PR TITLE
Fix msvc warning: unncessary conversions between int and size_t since…

### DIFF
--- a/boost/asynchronous/queue/any_queue_container.hpp
+++ b/boost/asynchronous/queue/any_queue_container.hpp
@@ -76,8 +76,7 @@ public:
         for (typename queues_type::const_iterator it = m_queues.begin(); it != m_queues.end();++it)
         {
             auto one_queue_vec = (*((*it).first)).get_queue_size();
-            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
-                                          [](std::size_t rhs,std::size_t lhs){return rhs + lhs;}));
+            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0)));
         }
         return res;
     }
@@ -87,7 +86,7 @@ public:
         for (typename queues_type::const_iterator it = m_queues.begin(); it != m_queues.end();++it)
         {
             auto one_queue_vec = (*((*it).first)).get_max_queue_size();
-            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
+            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0),
                                           [](std::size_t rhs,std::size_t lhs){return std::max(rhs,lhs);}));
         }
         return res;

--- a/boost/asynchronous/scheduler/composite_threadpool_scheduler.hpp
+++ b/boost/asynchronous/scheduler/composite_threadpool_scheduler.hpp
@@ -83,8 +83,7 @@ public:
         for (typename std::vector<subpool_type>::const_iterator it = m_subpools.begin(); it != m_subpools.end();++it)
         {
             auto one_queue_vec = (*it).get_queue_size();
-            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
-                                          [](std::size_t rhs,std::size_t lhs){return rhs + lhs;}));
+            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0)));
         }
         return res;
     }
@@ -94,7 +93,7 @@ public:
         for (typename std::vector<subpool_type>::const_iterator it = m_subpools.begin(); it != m_subpools.end();++it)
         {
             auto one_queue_vec = (*it).get_max_queue_size();
-            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
+            res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0),
                                           [](std::size_t rhs,std::size_t lhs){return std::max(rhs,lhs);}));
         }
         return res;
@@ -412,8 +411,7 @@ private:
             for (typename std::vector<boost::asynchronous::any_shared_scheduler<job_type> >::const_iterator it = m_schedulers.begin(); it != m_schedulers.end();++it)
             {
                 auto one_queue_vec = (*it).get_queue_size();
-                res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
-                                              [](std::size_t rhs,std::size_t lhs){return rhs + lhs;}));
+                res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0)));
             }
             return res;
         }
@@ -424,7 +422,7 @@ private:
             for (typename std::vector<boost::asynchronous::any_shared_scheduler<job_type> >::const_iterator it = m_schedulers.begin(); it != m_schedulers.end();++it)
             {
                 auto one_queue_vec = (*it).get_max_queue_size();
-                res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),0,
+                res.push_back(std::accumulate(one_queue_vec.begin(),one_queue_vec.end(),std::size_t(0),
                                               [](std::size_t rhs,std::size_t lhs){return std::max(rhs,lhs);}));
             }
             return res;

--- a/boost/asynchronous/scheduler/detail/multi_queue_scheduler_policy.hpp
+++ b/boost/asynchronous/scheduler/detail/multi_queue_scheduler_policy.hpp
@@ -45,7 +45,7 @@ public:
         for (typename std::vector<std::shared_ptr<queue_type> >::const_iterator it = m_queues.begin(); it != m_queues.end();++it)
         {
             auto vec = (*it)->get_queue_size();
-            res += std::accumulate(vec.begin(),vec.end(),0,[](std::size_t rhs,std::size_t lhs){return rhs + lhs;});
+            res += std::accumulate(vec.begin(),vec.end(),std::size_t(0));
         }
         std::vector<std::size_t> res_vec;
         res_vec.push_back(res);
@@ -58,7 +58,7 @@ public:
         for (typename std::vector<std::shared_ptr<queue_type> >::const_iterator it = m_queues.begin(); it != m_queues.end();++it)
         {
             auto vec = (*it)->get_max_queue_size();
-            res += std::accumulate(vec.begin(),vec.end(),0,[](std::size_t rhs,std::size_t lhs){return std::max(rhs,lhs);});
+            res += std::accumulate(vec.begin(),vec.end(),std::size_t(0),[](std::size_t rhs,std::size_t lhs){return std::max(rhs,lhs);});
         }
         std::vector<std::size_t> res_vec;
         res_vec.push_back(res);


### PR DESCRIPTION
… we init std::accumulate with int and thus also return int but have an binary op using size_t. If you want to accumulate size_t, then you need to init with size_t